### PR TITLE
Topic refaktor hiba javítások

### DIFF
--- a/src/evoKnowledgeShare/evoKnowledgeShare.Backend/Repositories/TopicRepository.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.Backend/Repositories/TopicRepository.cs
@@ -7,33 +7,43 @@ namespace evoKnowledgeShare.Backend.Repositories
     {
         public TopicRepository(EvoKnowledgeDbContext dbContext) : base(dbContext)
         {
+
         }
 
-        public override async Task AddAsync(Topic entity)
-        {
+        #region Add Section
+        public override async Task<Topic> AddAsync(Topic entity) {
+            Guid newEntityGuid = Guid.NewGuid();
+            entity.Id = newEntityGuid;
             await myDbContext.Topics.AddAsync(entity);
+            return myDbContext.Topics.First(x => x.Id == newEntityGuid);
         }
 
-        public override async Task AddRangeAsync(IEnumerable<Topic> entities)
-        {
-            throw new NotImplementedException();
+        public override async Task<IEnumerable<Topic>> AddRangeAsync(IEnumerable<Topic> entities) {
+            List<Topic> confirmationTopics = new List<Topic>();
+            foreach (Topic topic in entities)
+                confirmationTopics.Add(await AddAsync(topic));
+            return confirmationTopics;
         }
+        #endregion Add Section
 
-        public override IEnumerable<Topic> GetAll()
+        #region Get Section
+        public override IEnumerable<Topic> GetAll() 
         {
             return myDbContext.Topics;
         }
 
-        public override Topic GetById(Guid id)
+        public override Topic GetById(Guid id) 
         {
-            return myDbContext.Topics.FirstOrDefault(x => x.Id == id);
+            return myDbContext.Topics.First(x => x.Id == id);
         }
 
-        public override IEnumerable<Topic> GetRangeById(IEnumerable<Guid> ids)
+        public override IEnumerable<Topic> GetRangeById(IEnumerable<Guid> ids) 
         {
             return myDbContext.Topics.Where(x => ids.Any(y => x.Id == y));
         }
+        #endregion Get Section
 
+        #region Remove Section
         public override void Remove(Topic entity)
         {
             myDbContext.Topics.Remove(entity);
@@ -68,7 +78,9 @@ namespace evoKnowledgeShare.Backend.Repositories
                 }
             }
         }
+        #endregion Remove Section
 
+        #region Update Section
         public override Topic Update(Topic topic_in)
         {
             Topic topic = myDbContext.Topics.Update(topic_in).Entity;
@@ -78,10 +90,13 @@ namespace evoKnowledgeShare.Backend.Repositories
 
         public override IEnumerable<Topic> UpdateRange(IEnumerable<Topic> entities)
         {
-            foreach (var entity in entities)
+            List<Topic> confirmationTopics = new List<Topic>();
+            foreach (Topic topic in entities)
             {
-                myDbContext.Update(entity);
+                confirmationTopics.Add(Update(topic));
             }
+            return confirmationTopics;
         }
+        #endregion Update Section
     }
 }

--- a/src/evoKnowledgeShare/evoKnowledgeShare.Backend/Services/TopicService.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.Backend/Services/TopicService.cs
@@ -12,6 +12,7 @@ namespace evoKnowledgeShare.Backend.Services
             myRepository = repository;
         }
 
+        #region Get Section
         public IEnumerable<Topic> GetAll() => myRepository.GetAll();
 
         public Topic? GetById(Guid id) => myRepository.GetById(id);
@@ -19,9 +20,13 @@ namespace evoKnowledgeShare.Backend.Services
         public IEnumerable<Topic> GetByTitle(string title) => myRepository.GetAll().Where(x => x.Title == title).ToList();
 
         public IEnumerable<Topic> GetRangeById(IEnumerable<Guid> ids) => myRepository.GetRangeById(ids);
+        #endregion Get Section
 
+        #region Add Section
         public async Task AddAsync(Topic topic) => await myRepository.AddAsync(topic);
+        #endregion Add Section
 
+        #region Remove Section
         public void Remove(Topic entity) => myRepository.Remove(entity);
 
         public void RemoveById(Guid id) => myRepository.RemoveById(id);
@@ -29,9 +34,12 @@ namespace evoKnowledgeShare.Backend.Services
         public void RemoveRange(IEnumerable<Topic> entities) => myRepository.RemoveRange(entities);
 
         public void RemoveRangeById(IEnumerable<Guid> ids) => myRepository.RemoveRangeById(ids);
+        #endregion Remove Section
 
+        #region Update Section
         public Topic Update(Topic entity) => myRepository.Update(entity);
 
         public IEnumerable<Topic> UpdateRange(IEnumerable<Topic> entities) => myRepository.UpdateRange(entities);
+        #endregion Remove Section
     }
 }

--- a/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/ServiceTestBase.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/ServiceTestBase.cs
@@ -13,7 +13,6 @@ namespace evoKnowledgeShare.UnitTests.Services
     [TestFixture]
     public abstract class ServiceTestBase<T> where T : class
     {
-        protected TopicService myService = default!;
         protected Mock<IRepository<T>> myRepositoryMock = default!;
 
         [SetUp]

--- a/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/ServiceTestBase.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/ServiceTestBase.cs
@@ -1,0 +1,25 @@
+﻿using evoKnowledgeShare.Backend.Interfaces;
+using evoKnowledgeShare.Backend.Models;
+using evoKnowledgeShare.Backend.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace evoKnowledgeShare.UnitTests.Services 
+{
+    [TestFixture]
+    public abstract class ServiceTestBase<T> where T : class
+    {
+        protected TopicService myService = default!;
+        protected Mock<IRepository<T>> myRepositoryMock = default!;
+
+        [SetUp]
+        public void Setup() 
+        {
+            myRepositoryMock = new Mock<IRepository<T>>(MockBehavior.Strict);
+        }
+    }
+}

--- a/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/TopicServiceTests.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/TopicServiceTests.cs
@@ -5,8 +5,9 @@ using Moq;
 
 namespace evoKnowledgeShare.UnitTests.Services
 {
-    public class TopicServiceTests:ServiceTestBase<Topic>
+    public class TopicServiceTests:ServiceTestBase<Topic> 
     {
+        protected TopicService myService = default!;
         List<Topic> myTopics;
 
         [SetUp]

--- a/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/TopicServiceTests.cs
+++ b/src/evoKnowledgeShare/evoKnowledgeShare.UnitTests/Services/TopicServiceTests.cs
@@ -5,131 +5,98 @@ using Moq;
 
 namespace evoKnowledgeShare.UnitTests.Services
 {
-    public class TopicServiceTests
+    public class TopicServiceTests:ServiceTestBase<Topic>
     {
-        private TopicService myTopicService;
-        private Mock<IRepository<Topic>> myRepositoryMock;
+        List<Topic> myTopics;
 
         [SetUp]
-        public void Setup()
+        public void SetUp() 
         {
-            myRepositoryMock = new Mock<IRepository<Topic>>(MockBehavior.Strict);
-            myTopicService = new TopicService(myRepositoryMock.Object);
+            myService = new TopicService(myRepositoryMock.Object);
+            myTopics = new List<Topic> {
+                new Topic(Guid.NewGuid(), "Topic Test Title 1."),
+                new Topic(Guid.NewGuid(), "Topic Test Title 2."),
+                new Topic(Guid.NewGuid(), "Topic Test Title 3."),
+                new Topic(Guid.NewGuid(), "Topic Test Title 4."),
+                new Topic(Guid.NewGuid(), "Topic Test Title 5."),
+            };
         }
 
-        //GET TESTS
+        #region Get Test Section
         [Test]
         public void Topic_GetAll_ShouldReturnAll()
         {
-            var shouldReturnFirst = new Topic(1, "Topic Test Title 1.");
-            var shouldReturnSecond = new Topic(2, "Topic Test Title 2.");
+            myRepositoryMock.Setup(x => x.GetAll()).Returns(myTopics);
 
-            myRepositoryMock.Setup(x => x.GetAll()).Returns(() =>
-            {
-                return new List<Topic> {
-                    shouldReturnFirst,
-                    shouldReturnSecond
-                };
-            });
+            IEnumerable<Topic> actualTopics = myService.GetAll();
 
-            var actualTopics = myTopicService.GetAll();
-
-            Assert.That(Equals(actualTopics.ElementAt(0), shouldReturnFirst));
-            Assert.That(Equals(actualTopics.ElementAt(1), shouldReturnSecond));
-            Assert.That(actualTopics.Count, Is.EqualTo(2));
+            foreach (var topic in myTopics)
+                Assert.That(actualTopics.Contains(topic));
+            Assert.That(actualTopics.Count, Is.EqualTo(myTopics.Count));
         }
 
 
         [Test]
         public void Topic_GetById_ShouldReturnTopicWithSpecificId()
         {
-            var expectedTopic = new Topic(1, "Topic Test Title 1.");
+            Topic expectedTopic = new Topic(myTopics[2].Id, myTopics[2].Title);
+            myRepositoryMock.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(() => expectedTopic);
 
-            myRepositoryMock.Setup(x => x.GetById(It.IsAny<int>())).Returns(() => expectedTopic);
-
-            var actualTopic = myTopicService.GetById(expectedTopic.Id);
+            Topic actualTopic = myService.GetById(expectedTopic.Id)!;
 
             Assert.That(Equals(actualTopic, expectedTopic));
-            Assert.That(actualTopic?.Title, Is.EqualTo(expectedTopic.Title));
         }
 
         [Test]
         public void Topic_GetByTitle_ShouldReturnAListWhereItMatchesTitle()
         {
-            var expectedTopic = new Topic(1, "Topic Test Title 1.");
-            var notExpectedTopic = new Topic(2, "Topic Test Title 2.");
+            Topic expectedTopic = new Topic(myTopics[3].Id, myTopics[3].Title);
+            myRepositoryMock.Setup(x => x.GetAll()).Returns(myTopics);
 
-            myRepositoryMock.Setup(x => x.GetAll()).Returns(() =>
-            {
-                return new List<Topic> {
-                    expectedTopic,
-                    notExpectedTopic
-                };
-            });
+            IEnumerable<Topic> actualTopics = myService.GetByTitle(expectedTopic.Title);
 
-            var actualTopics = myTopicService.GetByTitle(expectedTopic.Title);
-
-            Assert.That(Equals(actualTopics.ElementAt(0), expectedTopic));
+            Assert.That(actualTopics.Contains(expectedTopic));
         }
 
         [Test]
         public void Topic_GetRangeById_ShouldReturnARangeOfIds()
         {
-            var shouldReturnFirst = new Topic(1, "Topic Test Title 1.");
-            var shouldReturnSecond = new Topic(2, "Topic Test Title 2.");
-
-            myRepositoryMock.Setup(x => x.GetRangeById(It.IsAny<IEnumerable<int>>())).Returns(new List<Topic> {
-                shouldReturnFirst,
-                shouldReturnSecond
+            Topic firstExpectedTopic = new Topic(myTopics[2].Id, myTopics[2].Title);
+            Topic secondExpectedTopic = new Topic(myTopics[4].Id, myTopics[4].Title);
+            myRepositoryMock.Setup(x => x.GetRangeById(It.IsAny<IEnumerable<Guid>>())).Returns(new List<Topic> {
+                firstExpectedTopic,
+                secondExpectedTopic
             });
 
-            var actualTopics = myTopicService.GetRangeById(new List<int> { 1, 3 });
+            IEnumerable<Topic> actualTopics = myService.GetRangeById(new List<Guid> { firstExpectedTopic.Id, secondExpectedTopic.Id });
 
-            Assert.That(Equals(actualTopics.ElementAt(0), shouldReturnFirst));
-            Assert.That(Equals(actualTopics.ElementAt(1), shouldReturnSecond));
+            Assert.That(actualTopics.Contains(firstExpectedTopic));
+            Assert.That(actualTopics.Contains(secondExpectedTopic));
             Assert.That(actualTopics.Count, Is.EqualTo(2));
         }
+        #endregion Get Test Section
 
-        //ADD TESTS
-
+        #region Add Test Region
         [Test]
-        public async Task Topic_Add_ShouldCallAddOnceAsync()
+        public async Task Topic_AddAsync_ShouldCallAddAsyncOnce()
         {
-            var addedTopic = new Topic(1, "Topic Test Title 1.");
-
+            Topic addedTopic = new Topic(myTopics[0].Id, myTopics[0].Title);
             myRepositoryMock.Setup(x => x.AddAsync(It.IsAny<Topic>()));
 
-            await myTopicService.AddAsync(addedTopic);
+            await myService.AddAsync(addedTopic);
 
             myRepositoryMock.Verify(x => x.AddAsync(addedTopic), Times.Once);
         }
+        #endregion Add Test Region
 
-        [Test]
-        public void Topic_AddRange_ShouldCallAddRangeOnce()
-        {
-            List<Topic> rangeOfTopics = new List<Topic> {
-                new Topic(1, "First Topic"),
-                new Topic(2, "Second Topic"),
-                new Topic(3, "Third Topic"),
-                new Topic(4, "Fourth Topic")
-            };
-
-            myRepositoryMock.Setup(x => x.AddRange(It.IsAny<IEnumerable<Topic>>()));
-
-            myTopicService.AddRange(rangeOfTopics);
-
-            myRepositoryMock.Verify(x => x.AddRange(rangeOfTopics), Times.Once);
-        }
-
-        //Remove Tests
+        #region Remove Test Region
         [Test]
         public void Topic_Remove_ShouldCallRemoveOnce()
         {
-            var removeTopic = new Topic(1, "Topic Test Title 1.");
-
+            Topic removeTopic = new Topic(myTopics[0].Id, myTopics[0].Title);
             myRepositoryMock.Setup(x => x.Remove(It.IsAny<Topic>()));
 
-            myTopicService.Remove(removeTopic);
+            myService.Remove(removeTopic);
 
             myRepositoryMock.Verify(x => x.Remove(removeTopic), Times.Once);
         }
@@ -137,11 +104,10 @@ namespace evoKnowledgeShare.UnitTests.Services
         [Test]
         public void Topic_RemoveById_ShouldCallRemoveByIdOnce()
         {
-            var removeId = 1;
+            Guid removeId = myTopics[2].Id;
+            myRepositoryMock.Setup(x => x.RemoveById(It.IsAny<Guid>()));
 
-            myRepositoryMock.Setup(x => x.RemoveById(It.IsAny<int>()));
-
-            myTopicService.RemoveById(removeId);
+            myService.RemoveById(removeId);
 
             myRepositoryMock.Verify(x => x.RemoveById(removeId), Times.Once);
         }
@@ -150,15 +116,14 @@ namespace evoKnowledgeShare.UnitTests.Services
         public void Topic_RemoveRange_ShouldCallRemoveRangeOnce()
         {
             List<Topic> removeRangeOfTopics = new List<Topic> {
-                new Topic(1, "First Topic"),
-                new Topic(2, "Second Topic"),
-                new Topic(3, "Third Topic"),
-                new Topic(4, "Fourth Topic")
+                new Topic(myTopics[0].Id, myTopics[0].Title),
+                new Topic(myTopics[1].Id, myTopics[1].Title),
+                new Topic(myTopics[2].Id, myTopics[2].Title),
+                new Topic(myTopics[3].Id, myTopics[3].Title)
             };
-
             myRepositoryMock.Setup(x => x.RemoveRange(It.IsAny<IEnumerable<Topic>>()));
 
-            myTopicService.RemoveRange(removeRangeOfTopics);
+            myService.RemoveRange(removeRangeOfTopics);
 
             myRepositoryMock.Verify(x => x.RemoveRange(removeRangeOfTopics), Times.Once);
         }
@@ -166,43 +131,42 @@ namespace evoKnowledgeShare.UnitTests.Services
         [Test]
         public void Topic_RemoveRangeById_ShouldCallRemoveRangeByIdOnce()
         {
-            List<int> removeRangeOfIds = new List<int> { 1, 2, 5, 6 };
+            List<Guid> removeRangeOfIds = new List<Guid> { myTopics[0].Id, myTopics[1].Id, myTopics[4].Id };
+            myRepositoryMock.Setup(x => x.RemoveRangeById(It.IsAny<IEnumerable<Guid>>()));
 
-            myRepositoryMock.Setup(x => x.RemoveRangeById(It.IsAny<IEnumerable<int>>()));
-
-            myTopicService.RemoveRangeById(removeRangeOfIds);
+            myService.RemoveRangeById(removeRangeOfIds);
 
             myRepositoryMock.Verify(x => x.RemoveRangeById(removeRangeOfIds), Times.Once);
         }
+        #endregion Remove Test Region
 
-        //Update Tests
+        #region Update Test Region
         [Test]
         public void Topic_Update_ShouldCallUpdateOnce()
         {
-            var updateTopic = new Topic(1, "Topic Test Title 1.");
-
+            Topic updateTopic = new Topic(myTopics[0].Id, myTopics[0].Title);
             myRepositoryMock.Setup(x => x.Update(It.IsAny<Topic>()));
 
-            myTopicService.Update(updateTopic);
+            myService.Update(updateTopic);
 
             myRepositoryMock.Verify(x => x.Update(updateTopic), Times.Once);
         }
 
         [Test]
-        public void Topic_UpdateRange_ShouldCallUpdateRangeOnce()
+        public void Topic_UpdateRange_ShouldCallUpdateRangeOnce() 
         {
             List<Topic> updateRangeOfTopics = new List<Topic> {
-                new Topic(1, "First Topic"),
-                new Topic(2, "Second Topic"),
-                new Topic(3, "Third Topic"),
-                new Topic(4, "Fourth Topic")
+                new Topic(myTopics[0].Id, myTopics[0].Title),
+                new Topic(myTopics[1].Id, myTopics[1].Title),
+                new Topic(myTopics[2].Id, myTopics[2].Title),
+                new Topic(myTopics[3].Id, myTopics[3].Title)
             };
-
             myRepositoryMock.Setup(x => x.UpdateRange(It.IsAny<IEnumerable<Topic>>()));
 
-            myTopicService.UpdateRange(updateRangeOfTopics);
+            myService.UpdateRange(updateRangeOfTopics);
 
             myRepositoryMock.Verify(x => x.UpdateRange(updateRangeOfTopics), Times.Once);
         }
+        #endregion Update Test Region
     }
 }


### PR DESCRIPTION
TopicService, TopicRepository hibák kijavítva.
Csináltam egy ServiceClassBase osztályt amiben a Setupot megoldjuk, jelenleg csak a Topichoz raktam be, ha esetleg mégse kellene ezt majd jelezd légyszi hogy töröljem-e. TopicServiceTests és TopicRepositoryTests kijavítva és RepositoryTestBase osztályból leszármaztatva. A TopicController és TopicControllerTests-re nem biztos hogy lesz időm péntekig de megpróbálom megcsinálni.